### PR TITLE
fix: prevent annotations from disappearing due to their being out-of-order

### DIFF
--- a/annotations.lua
+++ b/annotations.lua
@@ -150,8 +150,9 @@ function M.sync_callback(self, local_file, cached_file, income_file)
 
     if self and self.ui and self.ui.annotation then
         local merged_list = M.map_to_list(merged)
+        -- KOReader requires its annotation `pageno` values to be in ascending numerical order.
         table.sort(merged_list, function(a, b)
-            return (a.datetime_updated or a.datetime or 0) < (b.datetime_updated or b.datetime or 0)
+            return (a.pageno or -1) < (b.pageno or 0)
         end)
         self.ui.annotation.annotations = merged_list
         self.ui.annotation:onSaveSettings()


### PR DESCRIPTION
This change updates the merged list sort key to use `pageno` instead of a timestamp.

When arriving on a new page, KOReader appears to scan through annotations looking for ones for that page.

From the behavior I observed through experimentation, it appears that it uses an algorithm like this:

- Read annotations from the annotations table in order until a matching `pageno` is found.
- Continue reading and collecting annotations until `pageno` is greater than the current page.
- Stop reading annotations.

Due to this optimization, if we order annotations by timestamp before writing them back out, we can create a condition where an annotation added at a later date to a location in the book that is on an earlier page than an existing annotation, that new annotation will disappear from KOReader.

Annotations may appear in the KOReader sdr lua in non-sequential order within the subset of entries that have the same `pageno` value as long as all `pageno` groupings are in the correct order. So `pageno` ordering alone is sufficient.

Fixes #6