### PR TITLE
fix: hide AnnotationSync menu in irrelevant contexts

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -12,7 +12,8 @@ local remote = require("remote")
 local utils = require("utils")
 
 local AnnotationSyncPlugin = WidgetContainer:extend{
-    name = "AnnotationSync"
+    name = "AnnotationSync",
+    is_doc_only = true
 }
 
 function AnnotationSyncPlugin:init()


### PR DESCRIPTION
Teaches AnnotationSync to show its plugin menu only in a document context, since it cannot operate without an active document. This should help reduce clutter and confusion.