### PR TITLE
fix: address issues with "sync all"

### DIFF
--- a/annotations.lua
+++ b/annotations.lua
@@ -168,11 +168,13 @@ local function is_before(a, b)
 end
 
 
-function M.sync_callback(widget, local_file, last_sync_file, income_file)
+function M.sync_callback(widget, document, local_file, last_sync_file, income_file)
+    logger.dbg("AnnotationSync:sync_callback: local_file: " .. local_file)
+    logger.dbg("AnnotationSync:sync_callback: last_sync_file: " .. last_sync_file)
+    logger.dbg("AnnotationSync:sync_callback: income_file: " .. income_file)
     local local_map = utils.read_json(local_file)
     local last_sync_map = utils.read_json(last_sync_file)
     local income_map = utils.read_json(income_file)
-    local document = widget.ui.document
     -- Mark deleted annotations in local_map
     M.get_deleted_annotations(local_map, last_sync_map, document)
     local merged = {}
@@ -182,6 +184,7 @@ function M.sync_callback(widget, local_file, last_sync_file, income_file)
     local l = 1
     local i = 1
 
+    logger.dbg("AnnotationSync:sync_callback: comparing income and local")
     while i <= #income_keys and l <= #local_keys do
         local income_k = income_keys[i]
         local local_k = local_keys[l]
@@ -223,6 +226,7 @@ function M.sync_callback(widget, local_file, last_sync_file, income_file)
         i = i + 1
     end
 
+    logger.dbg("AnnotationSync:sync_callback: handling active")
     if widget and widget.ui and widget.ui.annotation then
         local merged_list = M.map_to_list(merged)
         table.sort(merged_list, function(a, b)

--- a/main.lua
+++ b/main.lua
@@ -130,7 +130,8 @@ function AnnotationSyncPlugin:syncDocument(document)
     end
     local json_path = sdr_dir .. "/" .. annotation_filename
     annotations.write_annotations_json(document, stored_annotations, sdr_dir, annotation_filename)
-    remote.sync_annotations(self, json_path)
+    logger.dbg("AnnotationSync: remote sync of " .. json_path)
+    remote.sync_annotations(self, document, json_path)
     -- Remove from changed_documents.lua if present (very last action)
     self:removeFromChangedDocumentsFile(document)
 end

--- a/remote.lua
+++ b/remote.lua
@@ -9,12 +9,12 @@ local annotations = require("annotations")
 
 local M = {}
 
-function M.sync_annotations(widget, json_path)
+function M.sync_annotations(widget, document, json_path)
     local server_json = G_reader_settings:readSetting("cloud_server_object")
     if server_json and server_json ~= "" then
         local server = json.decode(server_json)
         SyncService.sync(server, json_path, function(local_file, cached_file, income_file)
-            return annotations.sync_callback(widget, local_file, cached_file, income_file)
+            return annotations.sync_callback(widget, document, local_file, cached_file, income_file)
         end, false)
     else
         UIManager:show(InfoMessage:new {


### PR DESCRIPTION
Addresses various issues, primarily to fix "Sync All" issues (#19):

- Now uses `FlushSettings` event for annotations flush on the active document. `DocumentSettings:flush()` did not appear to be sufficient; in some cases it appeared that the subsquent `DocumentSettings:close()` would revert the changes we had just written in the preceding `DocumentSettings:flush()`.
- Now uses `ReaderAnnotation` and `LuaSettings` to retrieve the annotations for inactive documents (`ReaderUI` already provides access to annotations for the active document).
- Calls `render()` on inactive `crengine` documents in order to use their XPointer functions for annotation comparisons; KOReader will segfault otherwise!
- Adds `AnnotationSync: Sync All` action to "General" for use in profiles
- Refactored `manualSync` to use `syncDocument` implementation
- Some refactoring to reduce duplication and group like with like.
- Add `hold_callback` text to primary menu items.
- Disabled "Manual Sync" menu item when not in ReaderUI.
- Enable AnnotationSync menu outside of ReaderUI now that "Sync All" is always available.
- Minor adjustments to various UI messages.
- Add some `logger.dbg` messages to better trace sync progress with debug logs active.
- Pass a new `document` argument to `remote.sync_annotations` that in turn passes it along to `annotations.sync_callback` so that we do not have to render the document multiple times.