### PR TITLE
refactor(architecture): separate ui from logic

### DIFF
--- a/annotations.lua
+++ b/annotations.lua
@@ -1,23 +1,94 @@
 local docsettings = require("frontend/docsettings")
 local utils = require("utils")
 local json = require("json")
-local UIManager = require("ui/uimanager")
-local Event = require("ui/event")
-
 local logger = require("logger")
 
 local M = {}
 
-function M.flush_metadata(document, stored_annotations)
-    UIManager:broadcastEvent(Event:new("FlushSettings"))
+
+-- Main orchestration for merging local and remote annotations
+function M.sync_callback(document, local_file, last_sync_file, income_file, force)
+    logger.dbg("AnnotationSync:sync_callback: local_file: " .. local_file)
+    logger.dbg("AnnotationSync:sync_callback: last_sync_file: " .. last_sync_file)
+    logger.dbg("AnnotationSync:sync_callback: income_file: " .. income_file)
+
+    local local_map = utils.read_json(local_file)
+    local last_sync_map = utils.read_json(last_sync_file)
+    local income_map = utils.read_json(income_file)
+
+    if not local_map or not last_sync_map or not income_map then
+        logger.warn("AnnotationSync: Failed to load one or more sync files. Aborting to prevent data loss.")
+        return false
+    end
+
+    -- Mark deleted annotations in local_map
+    M.get_deleted_annotations(local_map, last_sync_map, document, force)
+    local merged = {}
+
+    local local_keys = M.sort_keys_by_position(local_map, document)
+    local income_keys = M.sort_keys_by_position(income_map, document)
+    local l = 1
+    local i = 1
+
+    logger.dbg("AnnotationSync:sync_callback: comparing income and local")
+    while i <= #income_keys and l <= #local_keys do
+        local income_k = income_keys[i]
+        local local_k = local_keys[l]
+        local income_v = income_map[income_k]
+        local local_v = local_map[local_k]
+
+        if M.positions_intersect(income_v, local_v, document) then
+            if M.is_before(income_v, local_v) then
+                merged[local_k] = local_v
+            else
+                merged[income_k] = income_v
+            end
+            i = i + 1
+            l = l + 1
+        else
+            local local_p = local_v.pos0 or local_v.page
+            local income_p = income_v.pos0 or income_v.page
+            local cmp = M.compare_positions(local_p, income_p, document)
+            if (cmp or 0) > 0 then
+                merged[local_k] = local_v
+                l = l + 1
+            else
+                merged[income_k] = income_v
+                i = i + 1
+            end
+        end
+    end
+
+    while l <= #local_keys do
+        local local_k = local_keys[l]
+        local local_v = local_map[local_k]
+        merged[local_k] = local_v
+        l = l + 1
+    end
+
+    while i <= #income_keys do
+        local income_k = income_keys[i]
+        local income_v = income_map[income_k]
+        merged[income_k] = income_v
+        i = i + 1
+    end
+
+    logger.dbg("AnnotationSync:sync_callback: handling merged list")
+    local merged_list = M.map_to_list(merged)
+
+    local f = io.open(local_file, "w")
+    if f then
+        f:write(json.encode(merged))
+        f:close()
+    end
+    return true, merged_list
 end
 
+-- Prepares the local sidecar data for syncing
 function M.write_annotations_json(document, stored_annotations, sdr_dir, annotation_filename)
     if not document or not sdr_dir then
         return false
     end
-    M.flush_metadata(document, stored_annotations)
-    local file = document.file
     local annotation_map = M.list_to_map(stored_annotations)
     local json_path = sdr_dir .. "/" .. annotation_filename
     local f = io.open(json_path, "w")
@@ -29,31 +100,57 @@ function M.write_annotations_json(document, stored_annotations, sdr_dir, annotat
     return false
 end
 
-function M.is_annotation(candidate)
-    return candidate and candidate.pos0 and candidate.pos1
-end
+-- Detects deletions by comparing local state with last known synced state
+function M.get_deleted_annotations(local_map, last_uploaded_map, document, force)
+    if type(last_uploaded_map) == "table" and type(local_map) == "table" then
+        local local_keys = M.sort_keys_by_position(local_map, document)
+        local uploaded_keys = M.sort_keys_by_position(last_uploaded_map, document)
 
-function M.is_bookmark(candidate)
-    return candidate and candidate.page and not M.is_annotation(candidate)
-end
-
-function M.annotation_key(annotation)
-    if M.is_annotation(annotation) then
-        local p0 = ""
-        local p1 = ""
-        if type(annotation.pos0) == "table" then
-            local zoom = annotation.pos0.zoom or 1
-            local page = annotation.page or annotation.pos0.page or 0
-            p0 = string.format("%d|%d|%d", page, math.floor(annotation.pos0.x / zoom), math.floor(annotation.pos0.y / zoom))
-            p1 = string.format("%d|%d", math.floor(annotation.pos1.x / zoom), math.floor(annotation.pos1.y / zoom))
-        else
-            p0 = annotation.pos0
-            p1 = annotation.pos1
+        -- SAFETY (Issue 23): If local is empty but last sync was not,
+        -- it's likely a docsettings failure or fresh device state.
+        -- We skip deletion propagation to avoid wiping remote data.
+        -- We bypass this safety if 'force' is true (manual sync).
+        if not force and #local_keys == 0 and #uploaded_keys > 0 then
+            logger.warn("AnnotationSync: Local annotations empty but last sync had " .. #uploaded_keys .. ". Skipping deletions to protect data.")
+            return
         end
-        return p0 .. "||" .. p1
-    elseif M.is_bookmark(annotation) then
-        return "BOOKMARK|" .. tostring(annotation.page)
+
+        for _, uploaded_k in ipairs(uploaded_keys) do
+            local uploaded_v = last_uploaded_map[uploaded_k]
+            local local_and_uploaded = false
+            for _, local_k in ipairs(local_keys) do
+                local local_v = local_map[local_k]
+                if M.positions_intersect(uploaded_v, local_v, document) then
+                    local_and_uploaded = true
+                    break
+                end
+                if M.compare_positions(local_v.page, uploaded_v.page, document) < 0 then
+                    break
+                end
+            end
+            if not local_and_uploaded then
+                uploaded_v.deleted = true
+                uploaded_v.datetime_updated = os.date("%Y-%m-%d %H:%M:%S")
+                local_map[uploaded_k] = uploaded_v
+            end
+        end
     end
+end
+
+-- Universal comparison logic for various annotation position types
+function M.compare_positions(a, b, document)
+    if not a or not b then return 0 end
+    if type(a) == "number" and type(b) == "number" then
+        return b - a
+    end
+    if type(a) == "string" and type(b) == "string" then
+        return document:compareXPointers(a, b) or 0
+    end
+    if type(a) == "table" and type(b) == "table" then
+        return document:comparePositions(a, b) or 0
+    end
+    -- Fallback for mixed types
+    return 0
 end
 
 function M.list_to_map(annotations)
@@ -83,24 +180,41 @@ function M.map_to_list(map)
     return list
 end
 
-local function compare_positions(a, b, document)
-    if not a or not b then return 0 end
-    if type(a) == "number" and type(b) == "number" then
-        return b - a
+-- Generates a unique key based on geometry or page
+function M.annotation_key(annotation)
+    if M.is_annotation(annotation) then
+        local p0 = ""
+        local p1 = ""
+        if type(annotation.pos0) == "table" then
+            local zoom = annotation.pos0.zoom or 1
+            local page = annotation.page or annotation.pos0.page or 0
+            p0 = string.format("%d|%d|%d", page, math.floor(annotation.pos0.x / zoom), math.floor(annotation.pos0.y / zoom))
+            p1 = string.format("%d|%d", math.floor(annotation.pos1.x / zoom), math.floor(annotation.pos1.y / zoom))
+        else
+            p0 = annotation.pos0
+            p1 = annotation.pos1
+        end
+        return p0 .. "||" .. p1
+    elseif M.is_bookmark(annotation) then
+        return "BOOKMARK|" .. tostring(annotation.page)
     end
-    if type(a) == "string" and type(b) == "string" then
-        return document:compareXPointers(a, b) or 0
-    end
-    if type(a) == "table" and type(b) == "table" then
-        return document:comparePositions(a, b) or 0
-    end
-    -- Fallback for mixed types (e.g. comparing page number vs XPointer)
-    -- We can't do a perfect comparison, but let's at least not crash.
-    -- Usually pageno is available in bookmarks and highlights can be mapped to page.
-    return 0
 end
 
-local function sort_keys_by_position(t, document)
+function M.is_annotation(candidate)
+    return candidate and candidate.pos0 and candidate.pos1
+end
+
+function M.is_bookmark(candidate)
+    return candidate and candidate.page and not M.is_annotation(candidate)
+end
+
+function M.is_before(a, b)
+    local a_time = a.datetime_updated or a.datetime or 0
+    local b_time = b.datetime_updated or b.datetime or 0
+    return a_time < b_time
+end
+
+function M.sort_keys_by_position(t, document)
     local keys = {}
     for k in pairs(t) do
         table.insert(keys, k)
@@ -110,13 +224,13 @@ local function sort_keys_by_position(t, document)
         local ann_b = t[b]
         local pos_a = ann_a.pos0 or ann_a.page
         local pos_b = ann_b.pos0 or ann_b.page
-        local cmp = compare_positions(pos_a, pos_b, document)
+        local cmp = M.compare_positions(pos_a, pos_b, document)
         return (cmp or 0) > 0
     end)
     return keys
 end
 
-local function positions_intersect(a, b, document)
+function M.positions_intersect(a, b, document)
     if not a or not b then
         return false
     end
@@ -130,156 +244,16 @@ local function positions_intersect(a, b, document)
     end
 
     -- A_Start <= B_Start <= A_End
-    if compare_positions(a.pos0, b.pos0, document) >= 0 and compare_positions(b.pos0, a.pos1, document) >= 0 then
+    if M.compare_positions(a.pos0, b.pos0, document) >= 0 and M.compare_positions(b.pos0, a.pos1, document) >= 0 then
         return true
     end
 
     -- B_Start <= A_Start <= B_End
-    if compare_positions(b.pos0, a.pos0, document) >= 0 and compare_positions(a.pos0, b.pos1, document) >= 0 then
+    if M.compare_positions(b.pos0, a.pos0, document) >= 0 and M.compare_positions(a.pos0, b.pos1, document) >= 0 then
         return true
     end
 
     return false
-end
-
-function M.get_deleted_annotations(local_map, last_uploaded_map, document)
-    if type(last_uploaded_map) == "table" and type(local_map) == "table" then
-        local local_keys = sort_keys_by_position(local_map, document)
-        local uploaded_keys = sort_keys_by_position(last_uploaded_map, document)
-
-        -- SAFETY (Issue 23): If local is empty but last sync was not, 
-        -- it's likely a docsettings failure or fresh device state.
-        -- We skip deletion propagation to avoid wiping remote data.
-        if #local_keys == 0 and #uploaded_keys > 0 then
-            logger.warn("AnnotationSync: Local annotations empty but last sync had " .. #uploaded_keys .. ". Skipping deletions to protect data.")
-            return
-        end
-
-        for _, uploaded_k in ipairs(uploaded_keys) do
-            local uploaded_v = last_uploaded_map[uploaded_k]
-            local local_and_uploaded = false
-            for _, local_k in ipairs(local_keys) do
-                local local_v = local_map[local_k]
-                if positions_intersect(uploaded_v, local_v, document) then
-                    local_and_uploaded = true
-                    break
-                end
-                if compare_positions(local_v.page, uploaded_v.page, document) < 0 then
-                    break
-                end
-            end
-            if not local_and_uploaded then
-                uploaded_v.deleted = true
-                uploaded_v.datetime_updated = os.date("%Y-%m-%d %H:%M:%S")
-                local_map[uploaded_k] = uploaded_v
-            end
-        end
-    end
-end
-
-local function is_before(a, b)
-    local a_time = a.datetime_updated or a.datetime or 0
-    local b_time = b.datetime_updated or b.datetime or 0
-    return a_time < b_time
-end
-
-
-function M.sync_callback(widget, document, local_file, last_sync_file, income_file)
-    logger.dbg("AnnotationSync:sync_callback: local_file: " .. local_file)
-    logger.dbg("AnnotationSync:sync_callback: last_sync_file: " .. last_sync_file)
-    logger.dbg("AnnotationSync:sync_callback: income_file: " .. income_file)
-    
-    local local_map = utils.read_json(local_file)
-    local last_sync_map = utils.read_json(last_sync_file)
-    local income_map = utils.read_json(income_file)
-
-    if not local_map or not last_sync_map or not income_map then
-        logger.warn("AnnotationSync: Failed to load one or more sync files. Aborting to prevent data loss.")
-        return false
-    end
-
-    -- Mark deleted annotations in local_map
-    M.get_deleted_annotations(local_map, last_sync_map, document)
-    local merged = {}
-
-    local local_keys = sort_keys_by_position(local_map, document)
-    local income_keys = sort_keys_by_position(income_map, document)
-    local l = 1
-    local i = 1
-
-    logger.dbg("AnnotationSync:sync_callback: comparing income and local")
-    while i <= #income_keys and l <= #local_keys do
-        local income_k = income_keys[i]
-        local local_k = local_keys[l]
-        local income_v = income_map[income_k]
-        local local_v = local_map[local_k]
-
-        if positions_intersect(income_v, local_v, document) then
-            if is_before(income_v, local_v) then
-                merged[local_k] = local_v
-            else
-                merged[income_k] = income_v
-            end
-            i = i + 1
-            l = l + 1
-        else
-            local local_p = local_v.pos0 or local_v.page
-            local income_p = income_v.pos0 or income_v.page
-            local cmp = compare_positions(local_p, income_p, document)
-            if (cmp or 0) > 0 then
-                merged[local_k] = local_v
-                l = l + 1
-            else
-                merged[income_k] = income_v
-                i = i + 1
-            end
-        end
-    end
-
-    while l <= #local_keys do
-        local local_k = local_keys[l]
-        local local_v = local_map[local_k]
-        merged[local_k] = local_v
-        l = l + 1
-    end
-
-    while i <= #income_keys do
-        local income_k = income_keys[i]
-        local income_v = income_map[income_k]
-        merged[income_k] = income_v
-        i = i + 1
-    end
-
-    logger.dbg("AnnotationSync:sync_callback: handling active")
-    local merged_list = M.map_to_list(merged)
-    if widget and widget.ui and widget.ui.annotation and widget.ui.document == document then
-        table.sort(merged_list, function(a, b)
-            local cmp = compare_positions(a.page, b.page, widget.ui.document)
-            return (cmp or 0) > 0
-        end)
-        widget.ui.annotation.annotations = merged_list
-        widget.ui.annotation:onSaveSettings()
-        if #merged_list > 0 then
-            UIManager:broadcastEvent(Event:new("AnnotationsModified", widget.ui.annotation.annotations))
-        end
-        if not widget.ui.document.is_pdf then
-            widget.ui.document:render()
-            widget.ui.view:recalculate()
-            UIManager:setDirty(widget.ui.view.dialog, "partial")
-        end
-    else
-        -- Update sidecar directly for inactive document or when no UI is present
-        local annotation_sidecar = docsettings:open(document.file)
-        annotation_sidecar:saveSetting("annotations", merged_list)
-        annotation_sidecar:flush()
-    end
-
-    local f = io.open(local_file, "w")
-    if f then
-        f:write(json.encode(merged))
-        f:close()
-    end
-    return true
 end
 
 return M

--- a/manager.lua
+++ b/manager.lua
@@ -1,0 +1,196 @@
+local DocumentRegistry = require("document/documentregistry")
+local DataStorage = require("datastorage")
+local util = require("util")
+local logger = require("logger")
+local _ = require("gettext")
+local docsettings = require("frontend/docsettings")
+local UIManager = require("ui/uimanager")
+local Event = require("ui/event")
+
+local annotations = require("annotations")
+local remote = require("remote")
+local utils = require("utils")
+
+local SyncManager = {}
+
+function SyncManager:new(plugin)
+    local o = {
+        plugin = plugin
+    }
+    setmetatable(o, self)
+    self.__index = self
+    return o
+end
+
+-- Sync all changed documents listed in changed_documents.lua
+function SyncManager:syncAllChangedDocuments()
+    local total, changed_docs = self:getPendingChangedDocuments()
+    if total == 0 then
+        utils.show_msg("No changed documents to sync.")
+        return
+    end
+    local count = 0
+    for file, _ in pairs(changed_docs) do
+        -- Try to get a document object for this file, open if needed
+        local document = self:getDocumentByFile(file)
+        if document then
+            self:syncDocument(document, false)
+            count = count + 1
+        end
+    end
+    if count == 0 then
+        utils.show_msg("Unable to sync modified documents: " .. total)
+    else
+        self:updateLastSync("Sync All")
+        utils.show_msg("Successfully synced modified documents: " .. count)
+    end
+end
+
+-- Orchestrates the sync process for a single document
+function SyncManager:syncDocument(document, is_manual)
+    local file = document and document.file
+    if not file then return end
+
+    self:_flushSettings()
+    logger.dbg("AnnotationSync: syncing document: " .. file)
+
+    local sdr_dir = docsettings:getSidecarDir(file)
+    if not sdr_dir or sdr_dir == "" then return end
+
+    local filename = self:_getAnnotationFilename(file)
+    local json_path = sdr_dir .. "/" .. filename
+
+    annotations.write_annotations_json(document, self:getAnnotationsForDocument(document), sdr_dir, filename)
+
+    logger.dbg("AnnotationSync: remote sync of " .. json_path .. " (force=" .. tostring(is_manual) .. ")")
+    remote.sync_annotations(self.plugin, document, json_path, function(success, merged_list)
+        self:_onSyncComplete(document, success, merged_list)
+    end, is_manual)
+end
+
+function SyncManager:changedDocumentsFile()
+    return DataStorage:getDataDir() .. "/changed_documents.lua"
+end
+
+function SyncManager:getPendingChangedDocuments()
+    local count = 0
+    local track_path = self:changedDocumentsFile()
+    local ok, changed_docs = pcall(dofile, track_path)
+    if ok and type(changed_docs) == "table" then
+        for _ in pairs(changed_docs) do count = count + 1 end
+    end
+    return count, changed_docs
+end
+
+function SyncManager:hasPendingChangedDocuments()
+    local count, _ = self:getPendingChangedDocuments()
+    return count > 0
+end
+
+function SyncManager:addToChangedDocumentsFile(file)
+    local track_path = self:changedDocumentsFile()
+    -- Load existing table or create new
+    local changed_docs = {}
+    local ok, loaded = pcall(dofile, track_path)
+    if ok and type(loaded) == "table" then
+        changed_docs = loaded
+    end
+    if file and type(file) == "string" then
+        changed_docs[file] = true
+        self:writeChangedDocumentsFile(changed_docs)
+    end
+end
+
+function SyncManager:removeFromChangedDocumentsFile(document)
+    local file = document and document.file
+    local track_path = self:changedDocumentsFile()
+    local ok, changed_docs = pcall(dofile, track_path)
+    if ok and type(changed_docs) == "table" and changed_docs[file] then
+        changed_docs[file] = nil
+        self:writeChangedDocumentsFile(changed_docs)
+    end
+end
+
+function SyncManager:writeChangedDocumentsFile(changed_docs)
+    local track_path = self:changedDocumentsFile()
+    local f = io.open(track_path, "w")
+    if f then
+        f:write("return ", self:_serialize_table(changed_docs), "\n")
+        f:close()
+    else
+        logger.warn("AnnotationSync: Failed to open changed documents file: " .. track_path)
+    end
+end
+
+-- Get annotations associated with given document
+function SyncManager:getAnnotationsForDocument(document)
+    -- Handle active document
+    if document == self.plugin.ui.document and self.plugin.ui.annotation and self.plugin.ui.annotation.annotations then
+        return self.plugin.ui.annotation.annotations
+    end
+    -- Handle inactive document
+    local annotation_sidecar = docsettings:open(document.file)
+    local result = annotation_sidecar:readSetting("annotations")
+    return result or {}
+end
+
+-- Helper to get a document object by file path
+function SyncManager:getDocumentByFile(file)
+    -- If only the current document is available, return it if it matches.
+    local document = self.plugin.ui and self.plugin.ui.document
+    if document and document.file == file then
+        return document
+    end
+    document = DocumentRegistry:openDocument(file)
+    -- crengine documents must be rendered in order to use their XPointer functions
+    if document.provider == "crengine" then
+        logger.dbg("AnnotationSync: rendering: " .. file)
+        document:render()
+    end
+    return document
+end
+
+function SyncManager:updateLastSync(descriptor)
+    local parenthetical = ""
+    if descriptor and type(descriptor) == "string" then
+        parenthetical = " (" .. descriptor .. ")"
+    end
+    self.plugin.settings.last_sync = os.date("%Y-%m-%d %H:%M:%S") .. parenthetical
+    logger.dbg("AnnotationSync: updateLastSync: updated at " .. self.plugin.settings.last_sync)
+end
+
+function SyncManager:_flushSettings()
+    UIManager:broadcastEvent(Event:new("FlushSettings"))
+end
+
+function SyncManager:_getAnnotationFilename(file)
+    if self.plugin.settings.use_filename then
+        local filename = file:match("([^/]+)$") or file
+        return filename .. ".json"
+    end
+    local hash = file and type(file) == "string" and util.partialMD5(file) or _("No hash")
+    return hash .. ".json"
+end
+
+function SyncManager:_onSyncComplete(document, success, merged_list)
+    if success then
+        if merged_list then
+            self.plugin:applySyncedAnnotations(document, merged_list)
+        end
+        self:removeFromChangedDocumentsFile(document)
+    else
+        logger.warn("AnnotationSync: sync failed for " .. (document.file or "unknown") .. ", keeping in changed list")
+    end
+end
+
+-- Helper to serialize a Lua table as code
+function SyncManager:_serialize_table(tbl)
+    local result = "{\n"
+    for k, v in pairs(tbl) do
+        result = result .. string.format("  [%q] = %s,\n", k, tostring(v))
+    end
+    result = result .. "}"
+    return result
+end
+
+return SyncManager

--- a/remote.lua
+++ b/remote.lua
@@ -9,14 +9,14 @@ local annotations = require("annotations")
 
 local M = {}
 
-function M.sync_annotations(widget, document, json_path, on_complete)
+function M.sync_annotations(widget, document, json_path, on_complete, force)
     local server_json = G_reader_settings:readSetting("cloud_server_object")
     if server_json and server_json ~= "" then
         local server = json.decode(server_json)
         SyncService.sync(server, json_path, function(local_file, cached_file, income_file)
-            local success = annotations.sync_callback(widget, document, local_file, cached_file, income_file)
+            local success, merged_list = annotations.sync_callback(document, local_file, cached_file, income_file, force)
             if on_complete then
-                on_complete(success)
+                on_complete(success, merged_list)
             end
             return success
         end, false)

--- a/spec/unit/error_handling_spec.lua
+++ b/spec/unit/error_handling_spec.lua
@@ -50,13 +50,13 @@ describe("AnnotationSync Integration - Battery 4 (Error Handling)", function()
         sync_instance.settings.use_filename = false
         sync_instance.settings.last_sync = "Never"
         
-        os.remove(sync_instance:changedDocumentsFile())
+        os.remove(sync_instance.manager:changedDocumentsFile())
     end)
 
     describe("4.1 Network & Server Errors", function()
         it("should keep document dirty if server is offline", function()
-            sync_instance:addToChangedDocumentsFile(readerui.document.file)
-            assert.is_true(sync_instance:hasPendingChangedDocuments())
+            sync_instance.manager:addToChangedDocumentsFile(readerui.document.file)
+            assert.is_true(sync_instance.manager:hasPendingChangedDocuments())
 
             -- Mock SyncService.sync to simulate a failure (callback never called)
             SyncService.sync = function(server, local_path, sync_cb, is_silent)
@@ -67,7 +67,7 @@ describe("AnnotationSync Integration - Battery 4 (Error Handling)", function()
             sync_instance:manualSync()
 
             -- Fixed: It should now remain dirty because the callback (which triggers removal) was never called
-            assert.is_true(sync_instance:hasPendingChangedDocuments())
+            assert.is_true(sync_instance.manager:hasPendingChangedDocuments())
         end)
 
         it("should handle malformed remote data gracefully and abort upload", function()

--- a/spec/unit/highlight_ground_truth_spec.lua
+++ b/spec/unit/highlight_ground_truth_spec.lua
@@ -39,7 +39,7 @@ describe("AnnotationSync Highlight Ground Truth Integration", function()
         UIManager:show(readerui)
         fastforward_ui_events()
         readerui.annotation.annotations = {}
-        os.remove(sync_instance:changedDocumentsFile())
+        os.remove(sync_instance.manager:changedDocumentsFile())
     end)
 
     it("should generate highlights for selected ground truth entries and track them", function()
@@ -63,7 +63,7 @@ describe("AnnotationSync Highlight Ground Truth Integration", function()
             assert.is_equal(entry.text, stored_ann.text)
         end
         
-        local count, changed_docs = sync_instance:getPendingChangedDocuments()
+        local count, changed_docs = sync_instance.manager:getPendingChangedDocuments()
         assert.is_equal(1, count)
         assert.is_true(changed_docs[readerui.document.file])
     end)

--- a/spec/unit/highlight_pdf_ground_truth_spec.lua
+++ b/spec/unit/highlight_pdf_ground_truth_spec.lua
@@ -45,7 +45,7 @@ describe("AnnotationSync PDF Highlight Ground Truth Integration", function()
         UIManager:show(readerui)
         fastforward_ui_events()
         readerui.annotation.annotations = {}
-        os.remove(sync_instance:changedDocumentsFile())
+        os.remove(sync_instance.manager:changedDocumentsFile())
     end)
 
     it("should generate highlights for selected PDF ground truth entries and track them", function()
@@ -71,7 +71,7 @@ describe("AnnotationSync PDF Highlight Ground Truth Integration", function()
             assert.is_equal(entry.text, stored_ann.text)
         end
         
-        local count, changed_docs = sync_instance:getPendingChangedDocuments()
+        local count, changed_docs = sync_instance.manager:getPendingChangedDocuments()
         assert.is_equal(1, count)
         assert.is_true(changed_docs[readerui.document.file])
     end)

--- a/spec/unit/sync_automation_spec.lua
+++ b/spec/unit/sync_automation_spec.lua
@@ -45,7 +45,7 @@ describe("AnnotationSync Automation & Settings", function()
         UIManager:show(readerui)
         fastforward_ui_events()
         readerui.annotation.annotations = {}
-        os.remove(sync_instance:changedDocumentsFile())
+        os.remove(sync_instance.manager:changedDocumentsFile())
         test_utils.mock_sync_service(SyncService)
     end)
 
@@ -73,7 +73,7 @@ describe("AnnotationSync Automation & Settings", function()
         it("triggers sync on NetworkConnected", function()
             sync_instance.settings.network_auto_sync = true
             sync_instance:registerEvents()
-            sync_instance:addToChangedDocumentsFile(readerui.document.file)
+            sync_instance.manager:addToChangedDocumentsFile(readerui.document.file)
 
             local sync_triggered = false
             SyncService.sync = function(server, local_path, callback, upload_only)
@@ -94,8 +94,8 @@ describe("AnnotationSync Automation & Settings", function()
             local doc1 = readerui.document.file
             local doc2 = "spec/front/unit/data/leaves.epub"
             
-            sync_instance:addToChangedDocumentsFile(doc1)
-            sync_instance:addToChangedDocumentsFile(doc2)
+            sync_instance.manager:addToChangedDocumentsFile(doc1)
+            sync_instance.manager:addToChangedDocumentsFile(doc2)
             
             local synced_files = {}
             SyncService.sync = function(server, local_path, callback, upload_only)
@@ -103,8 +103,8 @@ describe("AnnotationSync Automation & Settings", function()
                 callback(local_path, local_path, local_path)
             end
 
-            local old_getDoc = sync_instance.getDocumentByFile
-            sync_instance.getDocumentByFile = function(this, file)
+            local old_getDoc = sync_instance.manager.getDocumentByFile
+            sync_instance.manager.getDocumentByFile = function(this, file)
                 if file == doc1 then return readerui.document end
                 return { 
                     file = file, provider = "crengine", render = function() end,
@@ -112,10 +112,10 @@ describe("AnnotationSync Automation & Settings", function()
                 }
             end
             
-            sync_instance:syncAllChangedDocuments()
+            sync_instance.manager:syncAllChangedDocuments()
             assert.is_equal(2, #synced_files)
             
-            sync_instance.getDocumentByFile = old_getDoc
+            sync_instance.manager.getDocumentByFile = old_getDoc
         end)
     end)
 end)

--- a/spec/unit/sync_bookmark_spec.lua
+++ b/spec/unit/sync_bookmark_spec.lua
@@ -48,7 +48,7 @@ describe("AnnotationSync Bookmark Synchronization", function()
         UIManager:show(readerui)
         fastforward_ui_events()
         readerui.annotation.annotations = {}
-        os.remove(sync_instance:changedDocumentsFile())
+        os.remove(sync_instance.manager:changedDocumentsFile())
         test_utils.mock_sync_service(SyncService)
     end)
 
@@ -64,7 +64,7 @@ describe("AnnotationSync Bookmark Synchronization", function()
         assert.truthy(bm.page)
         assert.falsy(bm.pos0) -- bookmarks don't have coordinates
 
-        local count, docs = sync_instance:getPendingChangedDocuments()
+        local count, docs = sync_instance.manager:getPendingChangedDocuments()
         assert.is_equal(1, count)
         assert.is_true(docs[readerui.document.file])
     end)

--- a/spec/unit/sync_integration_spec.lua
+++ b/spec/unit/sync_integration_spec.lua
@@ -48,7 +48,7 @@ describe("AnnotationSync Core Integration", function()
         readerui.annotation.annotations = {}
         sync_instance.settings.last_sync = "Never"
         sync_instance.settings.use_filename = true
-        os.remove(sync_instance:changedDocumentsFile())
+        os.remove(sync_instance.manager:changedDocumentsFile())
         
         test_utils.mock_sync_service(SyncService)
     end)
@@ -73,12 +73,12 @@ describe("AnnotationSync Core Integration", function()
             fastforward_ui_events()
             test_utils.emulate_highlight(readerui, highlight_db[1])
 
-            local count, docs = sync_instance:getPendingChangedDocuments()
+            local count, docs = sync_instance.manager:getPendingChangedDocuments()
             assert.is_equal(1, count)
             assert.is_true(docs[readerui.document.file])
 
             sync_instance:manualSync()
-            assert.is_false(sync_instance:hasPendingChangedDocuments())
+            assert.is_false(sync_instance.manager:hasPendingChangedDocuments())
         end)
 
         it("handles first sync of an empty book gracefully", function()
@@ -117,7 +117,7 @@ describe("AnnotationSync Core Integration", function()
             -- 4. Should succeed, mark as clean, and have 1 annotation
             assert.is_not_equal("Never", sync_instance.settings.last_sync)
             assert.is_equal(1, #readerui.annotation.annotations)
-            assert.is_false(sync_instance:hasPendingChangedDocuments())
+            assert.is_false(sync_instance.manager:hasPendingChangedDocuments())
         end)
     end)
 

--- a/spec/unit/sync_mixed_offline_spec.lua
+++ b/spec/unit/sync_mixed_offline_spec.lua
@@ -56,7 +56,7 @@ describe("AnnotationSync Mixed Documents & Offline Sync All", function()
         UIManager:show(readerui)
         fastforward_ui_events()
         readerui.annotation.annotations = {}
-        os.remove(sync_instance:changedDocumentsFile())
+        os.remove(sync_instance.manager:changedDocumentsFile())
         test_utils.mock_sync_service(SyncService)
     end)
 
@@ -65,10 +65,10 @@ describe("AnnotationSync Mixed Documents & Offline Sync All", function()
         local doc_pdf = sample_pdf_dest
         
         -- 1. Mark both as dirty
-        sync_instance:addToChangedDocumentsFile(doc_epub)
-        sync_instance:addToChangedDocumentsFile(doc_pdf)
+        sync_instance.manager:addToChangedDocumentsFile(doc_epub)
+        sync_instance.manager:addToChangedDocumentsFile(doc_pdf)
         
-        assert.is_equal(2, (select(1, sync_instance:getPendingChangedDocuments())))
+        assert.is_equal(2, (select(1, sync_instance.manager:getPendingChangedDocuments())))
 
         -- 2. Mock OFFLINE server (callback never called)
         local sync_calls = 0
@@ -79,13 +79,13 @@ describe("AnnotationSync Mixed Documents & Offline Sync All", function()
         end
 
         -- 3. Trigger Sync All
-        sync_instance:syncAllChangedDocuments()
+        sync_instance.manager:syncAllChangedDocuments()
         
         -- Should have attempted to sync both
         assert.is_equal(2, sync_calls)
         
         -- 4. Verify both remain dirty because sync failed (callback never called)
-        local count, changed_docs = sync_instance:getPendingChangedDocuments()
+        local count, changed_docs = sync_instance.manager:getPendingChangedDocuments()
         assert.is_equal(2, count)
         assert.truthy(changed_docs[doc_epub])
         assert.truthy(changed_docs[doc_pdf])
@@ -96,10 +96,10 @@ describe("AnnotationSync Mixed Documents & Offline Sync All", function()
         end
 
         -- 6. Trigger Sync All again
-        sync_instance:syncAllChangedDocuments()
+        sync_instance.manager:syncAllChangedDocuments()
         
         -- 7. Verify both are now clean
-        assert.is_equal(0, (select(1, sync_instance:getPendingChangedDocuments())))
+        assert.is_equal(0, (select(1, sync_instance.manager:getPendingChangedDocuments())))
     end)
 
     it("Sync All performs full bidirectional merge for both mixed document types", function()
@@ -136,7 +136,7 @@ describe("AnnotationSync Mixed Documents & Offline Sync All", function()
         ann_pdf_l.pos1.page = 10
         ds_pdf:saveSetting("annotations", { ann_pdf_l })
         ds_pdf:flush()
-        sync_instance:addToChangedDocumentsFile(doc_pdf)
+        sync_instance.manager:addToChangedDocumentsFile(doc_pdf)
         
         -- Remote PDF addition
         local ann_pdf_r = util.tableDeepCopy(ann_pdf_l)
@@ -156,7 +156,7 @@ describe("AnnotationSync Mixed Documents & Offline Sync All", function()
         end
 
         -- 4. Sync All
-        sync_instance:syncAllChangedDocuments()
+        sync_instance.manager:syncAllChangedDocuments()
 
         -- 5. Verify EPUB (Active UI updated)
         assert.is_equal(2, #readerui.annotation.annotations)
@@ -166,6 +166,6 @@ describe("AnnotationSync Mixed Documents & Offline Sync All", function()
         local ann_pdf_after = ds_pdf_after:readSetting("annotations")
         assert.is_equal(2, #ann_pdf_after)
         
-        assert.is_equal(0, (select(1, sync_instance:getPendingChangedDocuments())))
+        assert.is_equal(0, (select(1, sync_instance.manager:getPendingChangedDocuments())))
     end)
 end)

--- a/spec/unit/sync_pdf_integration_spec.lua
+++ b/spec/unit/sync_pdf_integration_spec.lua
@@ -54,7 +54,7 @@ describe("AnnotationSync PDF Core Integration", function()
         readerui.annotation.annotations = {}
         sync_instance.settings.last_sync = "Never"
         sync_instance.settings.use_filename = true
-        os.remove(sync_instance:changedDocumentsFile())
+        os.remove(sync_instance.manager:changedDocumentsFile())
         
         test_utils.mock_sync_service(SyncService)
     end)
@@ -85,12 +85,12 @@ describe("AnnotationSync PDF Core Integration", function()
             fastforward_ui_events()
             test_utils.emulate_highlight(readerui, highlight_pdf_db[1])
 
-            local count, docs = sync_instance:getPendingChangedDocuments()
+            local count, docs = sync_instance.manager:getPendingChangedDocuments()
             assert.is_equal(1, count)
             assert.is_true(docs[readerui.document.file])
 
             sync_instance:manualSync()
-            assert.is_false(sync_instance:hasPendingChangedDocuments())
+            assert.is_false(sync_instance.manager:hasPendingChangedDocuments())
         end)
     end)
 
@@ -281,7 +281,7 @@ describe("AnnotationSync PDF Core Integration", function()
             assert.truthy(#key > 0)
             
             -- Verify it's tracked
-            local count, docs = sync_instance:getPendingChangedDocuments()
+            local count, docs = sync_instance.manager:getPendingChangedDocuments()
             assert.is_equal(1, count)
             
             -- Cleanup: DISABLE REFLOW before finishing

--- a/utils.lua
+++ b/utils.lua
@@ -1,6 +1,7 @@
 local reader_order = require("ui/elements/reader_menu_order")
 local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
+local json = require("json")
 
 local M = {}
 


### PR DESCRIPTION
refactor(utils): add implicitly used require

refactor(architecture): separate ui from logic

refactor(main): extract SyncManager

minor(ui): update last sync after update and not before

fix(sync): flush the settings before reading the stored annotations

refactor(annotations): sort functions top down

refactor(manager): sort functions top down

refactor(main): sort functions top down

refactor(manager): break syncDocument into smaller methods

refactor(manager): remove interleaved requires

fix(delete): fix an issue preventing to delete the last note