### PR TITLE
perf(restore): batch restoration to optimize performance

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -562,27 +562,39 @@ function AnnotationSyncPlugin:showDeletedAnnotations()
     menus.show_deleted_annotations(self, document)
 end
 
-function AnnotationSyncPlugin:restoreAnnotation(ann, silent)
+function AnnotationSyncPlugin:restoreAnnotations(anns, silent)
     local document = self.ui and self.ui.document
-    if not document then return end
+    if not document or not anns or #anns == 0 then return end
 
-    -- 1. Mark as not deleted and update timestamp
-    ann.deleted = false
-    ann.datetime_updated = os.date("%Y-%m-%d %H:%M:%S")
-    
-    -- 2. Add back to current list
+    local now = os.date("%Y-%m-%d %H:%M:%S")
     local current = self.manager:getAnnotationsForDocument(document)
-    table.insert(current, ann)
-    
-    -- 3. Apply changes (saves to sidecar and refreshes UI)
+
+    for _, ann in ipairs(anns) do
+        -- 1. Mark as not deleted and update timestamp
+        ann.deleted = false
+        ann.datetime_updated = now
+
+        -- 2. Add back to current list
+        table.insert(current, ann)
+    end
+
+    -- 3. Apply changes once (saves to sidecar and refreshes UI)
     self:applySyncedAnnotations(document, current)
 
     -- 4. Flush to local sync JSON immediately (Fix for Issue #39 delayed flush)
     self.manager:writeAnnotationsJSON(document)
 
     if not silent then
-        utils.show_msg(_("Annotation restored."))
+        if #anns == 1 then
+            utils.show_msg(_("Annotation restored."))
+        else
+            utils.show_msg(T(_("Restored %1 annotations."), #anns))
+        end
     end
+end
+
+function AnnotationSyncPlugin:restoreAnnotation(ann, silent)
+    self:restoreAnnotations({ann}, silent)
 end
 
 function AnnotationSyncPlugin:onAnnotationsModified(annotations)

--- a/menus.lua
+++ b/menus.lua
@@ -31,9 +31,7 @@ function M.show_deleted_annotations(plugin, document)
                 type = "yesno",
                 ok_text = _("Restore All"),
                 ok_callback = function()
-                    for _, ann in ipairs(deleted) do
-                        plugin:restoreAnnotation(ann, true) -- true = silent
-                    end
+                    plugin:restoreAnnotations(deleted, true) -- true = silent
                     utils.show_msg(T(_("Restored %1 annotations."), #deleted))
                     if deleted_menu then UIManager:close(deleted_menu) end
                 end

--- a/spec/unit/sync_trash_spec.lua
+++ b/spec/unit/sync_trash_spec.lua
@@ -114,15 +114,27 @@ describe("AnnotationSync Trash & Restore", function()
             { page = 2, pos0 = "p3", pos1 = "p4", text = "Two", deleted = true }
         }
 
-        -- 1. Restore all
-        for _, ann in ipairs(deleted_items) do
-            sync_instance:restoreAnnotation(ann, true) -- silent
+        -- Mock event broadcast tracking
+        local event_count = 0
+        local old_event_new = require("ui/event").new
+        require("ui/event").new = function(self_ev, name, ...)
+            if name == "AnnotationsModified" then
+                event_count = event_count + 1
+            end
+            return old_event_new(self_ev, name, ...)
         end
+
+        -- 1. Restore all
+        sync_instance:restoreAnnotations(deleted_items, true) -- silent
 
         -- 2. Verify
         assert.is_equal(2, #readerui.annotation.annotations)
         for _, ann in ipairs(readerui.annotation.annotations) do
             assert.is_false(ann.deleted)
         end
+        assert.is_equal(1, event_count, "AnnotationsModified event should only be broadcasted once")
+
+        -- Cleanup
+        require("ui/event").new = old_event_new
     end)
 end)


### PR DESCRIPTION
Batch multiple annotation restorations to avoid redundant UI refreshes, sidecar saves, and sync JSON flushes. Update the restore-all callback in menus and add unit tests to verify the single event broadcast.

Closes: #68 