### PR TITLE
fix(progress_sync): resend input after dismissing background sync

### DIFF
--- a/remote.lua
+++ b/remote.lua
@@ -243,7 +243,7 @@ function M.push_progress_bg(widget, json_path, on_complete)
                     end
                 end)
                 return sync_success
-            end, false)
+            end, true)
             if completed and not success then
                 logger.info("AnnotationSync: background progress sync failed/unsupported, falling back to in-process sync")
                 M.push_progress(widget, json_path, on_complete)

--- a/spec/unit/background_sync_spec.lua
+++ b/spec/unit/background_sync_spec.lua
@@ -87,6 +87,21 @@ describe("Background Sync Behavior", function()
         assert.is_true(on_complete_called)
     end)
 
+    it("push_progress_bg resends the dismiss input event", function()
+        local trap_widget_or_string
+        Trapper.dismissableRunInSubprocess = function(this, func, resend_event)
+            trap_widget_or_string = resend_event
+            local success = func()
+            return true, success
+        end
+
+        remote.push_progress_bg(mock_widget, "dummy.json", function(success)
+            assert.is_true(success)
+        end)
+
+        assert.is_true(trap_widget_or_string)
+    end)
+
     it("push_progress_bg fails silently (no UI) on error", function()
         -- Simulate sync failure
         SyncService.sync = function(server, local_path, callback, upload_only)


### PR DESCRIPTION
Background progress sync uses an invisible dismissible TrapWidget.
With event resending disabled, the input used to interrupt an active
sync is consumed instead of reaching the reader.

Enable event resending so user input can interrupt an obsolete
progress sync while still being handled normally by ReaderUI.
